### PR TITLE
build: require latest version of cursor

### DIFF
--- a/vscode/nostromo-ui/package.json
+++ b/vscode/nostromo-ui/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/LegoYoda112/nostromo_ui_themes"
   },
   "engines": {
-    "vscode": "^1.96.0"
+    "vscode": "^1.93.0"
   },
   "categories": [
     "Themes"


### PR DESCRIPTION
The most up-to-date version of Cursor uses VSCode 1.93.1 -- bumping the vscode version requirement down allows the theme to be used in Cursor IDE.